### PR TITLE
Switch to plist.parse() instead of plist.parseStringSync()

### DIFF
--- a/simple-plist.js
+++ b/simple-plist.js
@@ -64,5 +64,5 @@ exports.stringify = function(anObject) {
 
 
 exports.parse = function(aString) {
-	return plist.parseStringSync(aString);
+	return plist.parse(aString);
 }

--- a/simple-plist.js
+++ b/simple-plist.js
@@ -22,7 +22,7 @@ exports.readFileSync = function(aFile) {
 
 	try {
 		if (firstByte === 60) {
-			results = plist.parseStringSync(contents.toString());
+			results = plist.parse(contents.toString());
 		}
 		else if (firstByte === 98) {
 			results = bplistParser.parseBuffer(contents)[0];


### PR DESCRIPTION
`#parseStringSync()` is deprecated in favour of `#parse()`.