### PR TITLE
Minor release updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "bplist-creator": "0.0.7",
     "bplist-parser": "0.1.1",
-    "plist": "2.1.0"
+    "plist": "^3.0.1"
   },
   "devDependencies": {
     "coffee-script": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "plist": "^3.0.1"
   },
   "devDependencies": {
-    "coffee-script": "^1.11.1",
+    "coffeescript": "^2.3.2",
     "jest": "^16.0.2"
   }
 }


### PR DESCRIPTION
Followup to PR #17 which should be merged before this one.

I would recommend making a new minor release for these changes:

* plist@3
* package.json use coffeescript@2

Travis CI build is green on my fork (see <https://travis-ci.org/brodybits/node-simple-plist/builds/463998506>).

Travis CI build is green on Node.js 6, 8, and 10 if I merge this proposal together with PR #17 (see <https://travis-ci.org/brodybits/node-simple-plist/builds/464002613>).