### PR TITLE
test:verbose script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ node_js:
   - 6
   - 8
   - 10
+
+script:
+  - npm run test:verbose

--- a/package.json
+++ b/package.json
@@ -21,8 +21,10 @@
   ],
   "scripts": {
     "clean": "rimraf __tests__/write-test* coverage",
-    "jest": "jest --coverage",
-    "test": "run-s clean jest"
+    "jest": "jest --coverage ",
+    "jest:verbose": "jest --coverage --verbose",
+    "test": "run-s clean jest",
+    "test:verbose": "run-s clean jest:verbose"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
to run jest with --verbose flag

which is now used in .travis.yml

I am partly raising this to see if Travis CI works on PRs. I do not see Travis CI checkmarks in <https://github.com/wollardj/node-simple-plist/commits/master>.

Also it looks like the default branch of this project is `develop`, which does not have any commits since 2016.