### PR TITLE
Fix "undefined has errors" exception

### DIFF
--- a/__tests__/catch-invalid-plist.js
+++ b/__tests__/catch-invalid-plist.js
@@ -4,7 +4,7 @@ it('Throws an error on improperly formatted plist', () => {
   function doIt() {
     return plist.readFileSync(`${__dirname}/test-xml1-invalid.plist`)
   }
-  expect(doIt).toThrow(/has errors$/)
+  expect(doIt).toThrow()
 })
 
 it('returns an empty object when the file is zero bytes', () => {

--- a/simple-plist.js
+++ b/simple-plist.js
@@ -17,7 +17,7 @@ function parse(aStringOrBuffer, aFile) {
       throw new Error('Unable to determine format for plist aStringOrBuffer')
     }
   } catch (error) {
-    throw new Error(`${aFile} has errors`)
+    throw new Error(error)
   }
   return results
 }


### PR DESCRIPTION
This pull request fixes "undefined has errors" exceptions, also if a buffer is used and an exception is thrown in the `bplist-parser` module no information will be available.