### PR TITLE
In some cases, there may be an 0a byte before the 0x3c

### DIFF
--- a/simple-plist.js
+++ b/simple-plist.js
@@ -8,7 +8,7 @@ function parse(aStringOrBuffer, aFile) {
   const secondByte = aStringOrBuffer[1]
   let results
   try {
-    if (firstByte === 60 || firstByte === '<' || (firstByte === 10 && secondByte == 60)) {
+    if (firstByte === 60 || firstByte === '<' || (firstByte === 10 && secondByte === 60)) {
       results = plist.parse(aStringOrBuffer.toString())
     } else if (firstByte === 98) {
       ;[results] = bplistParser.parseBuffer(aStringOrBuffer)

--- a/simple-plist.js
+++ b/simple-plist.js
@@ -5,9 +5,10 @@ const fs = require('fs')
 
 function parse(aStringOrBuffer, aFile) {
   const firstByte = aStringOrBuffer[0]
+  const secondByte = aStringOrBuffer[1]
   let results
   try {
-    if (firstByte === 60 || firstByte === '<') {
+    if (firstByte === 60 || firstByte === '<' || (firstByte === 10 && secondByte == 60)) {
       results = plist.parse(aStringOrBuffer.toString())
     } else if (firstByte === 98) {
       ;[results] = bplistParser.parseBuffer(aStringOrBuffer)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5285945/91213649-d1467900-e709-11ea-928e-727d90853ef0.png)

In some cases, checking the first character fails. I'm not sure if there are other edge cases, but here's a stopgap fix. 
It would probably be better to look for the byte signature rather than just at the first or 2nd byte.

The code throws if `bplistParser` or `plist.parse` fail anyway...

Tested working on my side and the tests pass.