### PR TITLE
Fix default imports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
-export { default as bplistCreator } from "bplist-creator";
-export { default as bplistParser } from "bplist-parser";
+import * as bplistCreator from "bplist-creator";
+import * as bplistParser from "bplist-parser";
+
+export { bplistCreator }
+export { bplistParser }
 export { parse } from "./parse";
 export { readFile } from "./readFile";
 export { readFileSync } from "./readFileSync";


### PR DESCRIPTION
This pull request fixes the following errors when running a [Visual Studio Code Extension](https://code.visualstudio.com/api/get-started/your-first-extension):
```
node_modules/simple-plist/dist/index.d.ts:1:21 - error TS1259: Module '"bplist-creator"' can only be default-imported using the 'esModuleInterop' flag

1 export { default as bplistCreator } from "bplist-creator";
                      ~~~~~~~~~~~~~

  node_modules/bplist-creator/bplistCreator.d.ts:7:3
    7   export = BPlistCreator;
        ~~~~~~~~~~~~~~~~~~~~~~~
    This module is declared with 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.

node_modules/simple-plist/dist/index.d.ts:2:21 - error TS1259: Module '"/Users/dave/x/node_modules/bplist-parser/bplistParser"' can only be default-imported using the 'esModuleInterop' flag

2 export { default as bplistParser } from "bplist-parser";
                      ~~~~~~~~~~~~

  node_modules/bplist-parser/bplistParser.d.ts:8:1
    8 export = bPlistParser
      ~~~~~~~~~~~~~~~~~~~~~
    This module is declared with 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.


Found 2 errors in the same file, starting at: node_modules/simple-plist/dist/index.d.ts:1
```

Fixes changes introduced after https://github.com/wollardj/simple-plist/pull/65.